### PR TITLE
Updating CVE url

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@ No:
 # 🍿 wait a sec, did you say "executable yaml"?? 🍿
 # - https://ruby-doc.org/stdlib-2.4.0/libdoc/yaml/rdoc/YAML.html#module-YAML-label-Security
 # - https://www.php.net/manual/en/function.yaml-parse.php#refsect1-function.yaml-parse-notes
-# - https://lgtm.com/blog/swagger_snakeyaml_CVE-2017-1000207_CVE-2017-1000208
+# - https://securitylab.github.com/research/swagger-yaml-parser-vulnerability/
 # - https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation
 
 # 🚨 Anyone who uses YAML long enough will eventually get burned when attempting to abbreviate Norway 🚨


### PR DESCRIPTION
The url from lgtm.com doesn't redirect to any blog, so I update the url to the github security blog